### PR TITLE
Reopen mac app window after closing

### DIFF
--- a/AppDelegate.swift
+++ b/AppDelegate.swift
@@ -1,0 +1,50 @@
+import Cocoa
+import SwiftUI
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    var window: NSWindow!
+    
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // 创建主窗口
+        let contentView = ContentView()
+        
+        window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 300),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        
+        window.isReleasedWhenClosed = false
+        window.center()
+        window.setFrameAutosaveName("Main Window")
+        window.contentView = NSHostingView(rootView: contentView)
+        window.makeKeyAndOrderFront(nil)
+        
+        // 设置窗口关闭行为
+        window.delegate = self
+    }
+    
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        // 当点击Dock图标时，如果没有可见窗口，则显示主窗口
+        if !flag {
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+        return true
+    }
+    
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        // 当最后一个窗口关闭时，不自动退出应用
+        return false
+    }
+}
+
+// MARK: - NSWindowDelegate
+extension AppDelegate: NSWindowDelegate {
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        // 当用户点击关闭按钮时，隐藏窗口而不是关闭
+        sender.orderOut(nil)
+        return false
+    }
+}

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "macwindow")
+                .font(.system(size: 60))
+                .foregroundColor(.blue)
+            
+            Text("Mac 窗口重新打开示例")
+                .font(.title)
+                .fontWeight(.bold)
+            
+            Text("关闭此窗口后，点击 Dock 中的应用图标可以重新打开")
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.secondary)
+            
+            Button("关闭窗口") {
+                // 关闭窗口（隐藏应用）
+                NSApplication.shared.hide(nil)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+        }
+        .padding(40)
+        .frame(minWidth: 400, minHeight: 300)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright © 2024. All rights reserved.</string>
+    <key>NSMainNibFile</key>
+    <string>MainMenu</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>LSUIElement</key>
+    <false/>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ReopenMacApp",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(
+            name: "ReopenMacApp",
+            targets: ["ReopenMacApp"]
+        )
+    ],
+    targets: [
+        .executableTarget(
+            name: "ReopenMacApp",
+            dependencies: [],
+            path: ".",
+            sources: [
+                "ReopenMacAppApp.swift",
+                "ContentView.swift",
+                "AppDelegate.swift"
+            ]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,82 @@
-# bare
+# Mac 应用窗口重新打开示例
+
+这个项目演示了如何实现Mac应用窗口关闭后，通过点击Dock图标重新打开窗口的功能。
+
+## 功能特性
+
+- ✅ 点击窗口关闭按钮时隐藏窗口而不是退出应用
+- ✅ 点击Dock中的应用图标重新显示窗口
+- ✅ 使用SwiftUI构建现代化界面
+- ✅ 支持macOS 13.0+
+
+## 核心实现原理
+
+### 1. 窗口关闭行为控制
+```swift
+func windowShouldClose(_ sender: NSWindow) -> Bool {
+    // 当用户点击关闭按钮时，隐藏窗口而不是关闭
+    sender.orderOut(nil)
+    return false
+}
+```
+
+### 2. 应用重新打开处理
+```swift
+func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+    // 当点击Dock图标时，如果没有可见窗口，则显示主窗口
+    if !flag {
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+    return true
+}
+```
+
+### 3. 防止应用自动退出
+```swift
+func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    // 当最后一个窗口关闭时，不自动退出应用
+    return false
+}
+```
+
+## 构建和运行
+
+### 使用 Swift Package Manager
+```bash
+swift build
+swift run
+```
+
+### 使用 Xcode
+1. 在 Xcode 中打开项目
+2. 选择目标设备为 Mac
+3. 点击运行按钮
+
+## 项目结构
+
+- `ReopenMacAppApp.swift` - 主应用入口
+- `ContentView.swift` - 主界面视图
+- `AppDelegate.swift` - 应用委托，处理窗口生命周期
+- `Info.plist` - 应用配置文件
+- `Package.swift` - Swift Package Manager 配置
+
+## 关键配置
+
+### Info.plist 设置
+- `LSUIElement`: 设置为 `false`，确保应用在Dock中显示
+- `NSHighResolutionCapable`: 支持高分辨率显示
+- `NSSupportsAutomaticGraphicsSwitching`: 支持自动图形切换
+
+## 使用说明
+
+1. 运行应用后，会显示一个包含关闭按钮的窗口
+2. 点击窗口的关闭按钮（红色圆点），窗口会隐藏但应用不会退出
+3. 点击Dock中的应用图标，窗口会重新显示
+4. 应用会继续在后台运行，直到手动退出
+
+## 注意事项
+
+- 确保 `window.isReleasedWhenClosed = false` 以防止窗口被释放
+- 使用 `NSApp.activate(ignoringOtherApps: true)` 确保窗口获得焦点
+- 在 `applicationShouldTerminateAfterLastWindowClosed` 中返回 `false` 防止自动退出

--- a/ReopenMacAppApp.swift
+++ b/ReopenMacAppApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct ReopenMacAppApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+    }
+}


### PR DESCRIPTION
Implement standard macOS window behavior where closing a window hides it, and clicking the Dock icon reopens it, preventing app termination.

This PR provides a complete example of how to manage a Mac app's window lifecycle, ensuring the application remains active in the background when its window is closed, and can be easily brought back into view by clicking its icon in the Dock. This is a common and expected user experience for macOS applications.

---
<a href="https://cursor.com/background-agent?bcId=bc-acec9f65-c149-48ab-a8f9-e00f0436cd0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-acec9f65-c149-48ab-a8f9-e00f0436cd0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

